### PR TITLE
:fire: (flake): remove unused

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,20 +131,6 @@
     # Nixcord
     nixcord.url = "github:kaylorben/nixcord";
 
-    # Niri
-    niri.url = "github:sodiboo/niri-flake";
-    niri.inputs.nixpkgs.follows = "nixpkgs";
-
-    # fabric
-    fabric.url = "github:Fabric-Development/fabric";
-    fabric.inputs.nixpkgs.follows = "nixpkgs";
-
-    fabric-cli.url = "github:HeyImKyu/fabric-cli";
-    fabric-cli.inputs.nixpkgs.follows = "nixpkgs";
-
-    fabric-gray.url = "github:Fabric-Development/gray";
-    fabric-gray.inputs.nixpkgs.follows = "nixpkgs";
-
     quickshell.url = "git+https://git.outfoxxed.me/outfoxxed/quickshell";
     quickshell.inputs.nixpkgs.follows = "nixpkgs";
   };


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove niri, fabric, fabric-cli, and fabric-gray inputs from the flake configuration